### PR TITLE
6.3.13

### DIFF
--- a/src/Horse.Messaging.Client/Horse.Messaging.Client.csproj
+++ b/src/Horse.Messaging.Client/Horse.Messaging.Client.csproj
@@ -7,9 +7,9 @@
         <Product>Horse.Messaging.Client</Product>
         <Description>Horse Messaging Client to connect all Horse Servers</Description>
         <PackageTags>horse,client,messaging,queue,channel,cache</PackageTags>
-        <AssemblyVersion>6.3.12</AssemblyVersion>
-        <FileVersion>6.3.12</FileVersion>
-        <PackageVersion>6.3.12</PackageVersion>
+        <AssemblyVersion>6.3.13</AssemblyVersion>
+        <FileVersion>6.3.13</FileVersion>
+        <PackageVersion>6.3.13</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/horse-framework/horse-messaging</PackageProjectUrl>

--- a/src/Horse.Messaging.Client/Horse.Messaging.Client.csproj
+++ b/src/Horse.Messaging.Client/Horse.Messaging.Client.csproj
@@ -7,9 +7,9 @@
         <Product>Horse.Messaging.Client</Product>
         <Description>Horse Messaging Client to connect all Horse Servers</Description>
         <PackageTags>horse,client,messaging,queue,channel,cache</PackageTags>
-        <AssemblyVersion>6.3.11</AssemblyVersion>
-        <FileVersion>6.3.11</FileVersion>
-        <PackageVersion>6.3.11</PackageVersion>
+        <AssemblyVersion>6.3.12</AssemblyVersion>
+        <FileVersion>6.3.12</FileVersion>
+        <PackageVersion>6.3.12</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/horse-framework/horse-messaging</PackageProjectUrl>

--- a/src/Horse.Messaging.Client/Horse.Messaging.Client.csproj
+++ b/src/Horse.Messaging.Client/Horse.Messaging.Client.csproj
@@ -7,9 +7,9 @@
         <Product>Horse.Messaging.Client</Product>
         <Description>Horse Messaging Client to connect all Horse Servers</Description>
         <PackageTags>horse,client,messaging,queue,channel,cache</PackageTags>
-        <AssemblyVersion>6.3.10</AssemblyVersion>
-        <FileVersion>6.3.10</FileVersion>
-        <PackageVersion>6.3.10</PackageVersion>
+        <AssemblyVersion>6.3.11</AssemblyVersion>
+        <FileVersion>6.3.11</FileVersion>
+        <PackageVersion>6.3.11</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/horse-framework/horse-messaging</PackageProjectUrl>

--- a/src/Horse.Messaging.Client/Queues/Internal/MessageTracker.cs
+++ b/src/Horse.Messaging.Client/Queues/Internal/MessageTracker.cs
@@ -113,15 +113,16 @@ namespace Horse.Messaging.Client.Queues.Internal
             if (message.Type != MessageType.Response || string.IsNullOrEmpty(message.MessageId))
                 return;
 
-            MessageDescriptor descriptor;
             lock (_descriptors)
-                descriptor = _descriptors.Find(x => x.Message.WaitResponse && x.Message.MessageId == message.MessageId);
+            {
+                MessageDescriptor descriptor = _descriptors.Find(x => x.Message.WaitResponse && x.Message.MessageId == message.MessageId && !x.Completed);
 
-            if (descriptor == null)
-                return;
+                if (descriptor == null)
+                    return;
 
-            descriptor.Completed = true;
-            descriptor.Set(true, message);
+                descriptor.Completed = true;
+                descriptor.Set(true, message);
+            }
         }
 
         /// <summary>

--- a/src/Horse.Messaging.Client/Queues/QueueOperator.cs
+++ b/src/Horse.Messaging.Client/Queues/QueueOperator.cs
@@ -473,7 +473,7 @@ namespace Horse.Messaging.Client.Queues
                 container.Complete("Error");
             }
 
-            return await container.GetAwaitableTask();
+            return await container.GetAwaitableTask().ConfigureAwait(false);
         }
 
         #endregion

--- a/src/Horse.Messaging.Data/Database.cs
+++ b/src/Horse.Messaging.Data/Database.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -93,10 +94,10 @@ namespace Horse.Messaging.Data
             {
                 if (IsOpen)
                     return;
-                
+
                 IsOpen = true;
             }
-            
+
             await File.Open();
             await Load();
 
@@ -155,7 +156,7 @@ namespace Horse.Messaging.Data
         {
             lock (File)
                 IsOpen = false;
-            
+
             _shrinkManager.Stop();
             await Shrink();
             await File.Close();
@@ -206,8 +207,8 @@ namespace Horse.Messaging.Data
                     count = _deletedMessages.Count;
                     position = stream.Position;
                     msgs = _deletedMessages.Count > 0
-                               ? new List<string>(_deletedMessages)
-                               : new List<string>();
+                        ? new List<string>(_deletedMessages)
+                        : new List<string>();
                 }
                 finally
                 {
@@ -287,7 +288,7 @@ namespace Horse.Messaging.Data
             try
             {
                 if (_messages.ContainsKey(message.MessageId))
-                    return false;
+                    throw new DuplicateNameException("Another message with same id is already in queue");
 
                 _messages.Add(message.MessageId, message);
                 Stream stream = File.GetStream();
@@ -299,6 +300,10 @@ namespace Horse.Messaging.Data
                     File.FlushRequired = true;
 
                 return true;
+            }
+            catch (DuplicateNameException)
+            {
+                throw;
             }
             catch (Exception e)
             {

--- a/src/Horse.Messaging.Data/Database.cs
+++ b/src/Horse.Messaging.Data/Database.cs
@@ -319,12 +319,12 @@ namespace Horse.Messaging.Data
         /// <summary>
         /// Deletes the message from database
         /// </summary>
-        public async Task<bool> Delete(HorseMessage message)
+        public Task<bool> Delete(HorseMessage message)
         {
             if (string.IsNullOrEmpty(message.MessageId))
-                return false;
+                return Task.FromResult(false);
 
-            return await Delete(message.MessageId);
+            return Delete(message.MessageId);
         }
 
         /// <summary>
@@ -369,6 +369,7 @@ namespace Horse.Messaging.Data
             await WaitForLock();
             try
             {
+                _messages.Clear();
                 Stream stream = File.GetStream();
                 stream.SetLength(0);
                 await stream.FlushAsync();

--- a/src/Horse.Messaging.Data/Horse.Messaging.Data.csproj
+++ b/src/Horse.Messaging.Data/Horse.Messaging.Data.csproj
@@ -7,9 +7,9 @@
         <Product>Horse.Messaging.Data</Product>
         <Description>Persistant queue message data library for Horse Messaging</Description>
         <PackageTags>horse,server,messaging,queue,mq,persistent,database,db</PackageTags>
-        <AssemblyVersion>6.3.12</AssemblyVersion>
-        <FileVersion>6.3.12</FileVersion>
-        <PackageVersion>6.3.12</PackageVersion>
+        <AssemblyVersion>6.3.13</AssemblyVersion>
+        <FileVersion>6.3.13</FileVersion>
+        <PackageVersion>6.3.13</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/horse-framework/horse-messaging</PackageProjectUrl>

--- a/src/Horse.Messaging.Data/Horse.Messaging.Data.csproj
+++ b/src/Horse.Messaging.Data/Horse.Messaging.Data.csproj
@@ -7,9 +7,9 @@
         <Product>Horse.Messaging.Data</Product>
         <Description>Persistant queue message data library for Horse Messaging</Description>
         <PackageTags>horse,server,messaging,queue,mq,persistent,database,db</PackageTags>
-        <AssemblyVersion>6.3.11</AssemblyVersion>
-        <FileVersion>6.3.11</FileVersion>
-        <PackageVersion>6.3.11</PackageVersion>
+        <AssemblyVersion>6.3.12</AssemblyVersion>
+        <FileVersion>6.3.12</FileVersion>
+        <PackageVersion>6.3.12</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/horse-framework/horse-messaging</PackageProjectUrl>

--- a/src/Horse.Messaging.Data/Horse.Messaging.Data.csproj
+++ b/src/Horse.Messaging.Data/Horse.Messaging.Data.csproj
@@ -7,9 +7,9 @@
         <Product>Horse.Messaging.Data</Product>
         <Description>Persistant queue message data library for Horse Messaging</Description>
         <PackageTags>horse,server,messaging,queue,mq,persistent,database,db</PackageTags>
-        <AssemblyVersion>6.3.10</AssemblyVersion>
-        <FileVersion>6.3.10</FileVersion>
-        <PackageVersion>6.3.10</PackageVersion>
+        <AssemblyVersion>6.3.11</AssemblyVersion>
+        <FileVersion>6.3.11</FileVersion>
+        <PackageVersion>6.3.11</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/horse-framework/horse-messaging</PackageProjectUrl>

--- a/src/Horse.Messaging.Data/Implementation/PersistentMessageDeliveryHandler.cs
+++ b/src/Horse.Messaging.Data/Implementation/PersistentMessageDeliveryHandler.cs
@@ -32,7 +32,7 @@ namespace Horse.Messaging.Data.Implementation
         /// <inheritdoc />
         public async Task<Decision> ReceivedFromProducer(HorseQueue queue, QueueMessage message, MessagingClient sender)
         {
-            if (_manager.Queue.Options.CommitWhen == CommitWhen.AfterSaved)
+            if (_manager.Queue.Options.CommitWhen == CommitWhen.AfterReceived)
             {
                 message.IsSaved = await _manager.SaveMessage(message);
 

--- a/src/Horse.Messaging.Extensions.Client/Horse.Messaging.Extensions.Client.csproj
+++ b/src/Horse.Messaging.Extensions.Client/Horse.Messaging.Extensions.Client.csproj
@@ -7,9 +7,9 @@
         <Product>Horse.Messaging.Data</Product>
         <Description>Horse messaging extensions library</Description>
         <PackageTags>horse,server,messaging,queue,mq,persistent,database,db</PackageTags>
-        <AssemblyVersion>6.3.10</AssemblyVersion>
-        <FileVersion>6.3.10</FileVersion>
-        <PackageVersion>6.3.10</PackageVersion>
+        <AssemblyVersion>6.3.11</AssemblyVersion>
+        <FileVersion>6.3.11</FileVersion>
+        <PackageVersion>6.3.11</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/horse-framework/horse-messaging</PackageProjectUrl>

--- a/src/Horse.Messaging.Extensions.Client/Horse.Messaging.Extensions.Client.csproj
+++ b/src/Horse.Messaging.Extensions.Client/Horse.Messaging.Extensions.Client.csproj
@@ -7,9 +7,9 @@
         <Product>Horse.Messaging.Data</Product>
         <Description>Horse messaging extensions library</Description>
         <PackageTags>horse,server,messaging,queue,mq,persistent,database,db</PackageTags>
-        <AssemblyVersion>6.3.11</AssemblyVersion>
-        <FileVersion>6.3.11</FileVersion>
-        <PackageVersion>6.3.11</PackageVersion>
+        <AssemblyVersion>6.3.12</AssemblyVersion>
+        <FileVersion>6.3.12</FileVersion>
+        <PackageVersion>6.3.12</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/horse-framework/horse-messaging</PackageProjectUrl>

--- a/src/Horse.Messaging.Extensions.Client/Horse.Messaging.Extensions.Client.csproj
+++ b/src/Horse.Messaging.Extensions.Client/Horse.Messaging.Extensions.Client.csproj
@@ -7,9 +7,9 @@
         <Product>Horse.Messaging.Data</Product>
         <Description>Horse messaging extensions library</Description>
         <PackageTags>horse,server,messaging,queue,mq,persistent,database,db</PackageTags>
-        <AssemblyVersion>6.3.12</AssemblyVersion>
-        <FileVersion>6.3.12</FileVersion>
-        <PackageVersion>6.3.12</PackageVersion>
+        <AssemblyVersion>6.3.13</AssemblyVersion>
+        <FileVersion>6.3.13</FileVersion>
+        <PackageVersion>6.3.13</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/horse-framework/horse-messaging</PackageProjectUrl>

--- a/src/Horse.Messaging.Protocol/Horse.Messaging.Protocol.csproj
+++ b/src/Horse.Messaging.Protocol/Horse.Messaging.Protocol.csproj
@@ -7,9 +7,9 @@
         <Product>Horse.Messaging.Protocol</Product>
         <Description>Horse Messaging Protocol library and server extension for Horse Server</Description>
         <PackageTags>horse,tcp,server,http,messaging,queue,cache,channel,stream,protocol</PackageTags>
-        <AssemblyVersion>6.3.11</AssemblyVersion>
-        <FileVersion>6.3.11</FileVersion>
-        <PackageVersion>6.3.11</PackageVersion>
+        <AssemblyVersion>6.3.12</AssemblyVersion>
+        <FileVersion>6.3.12</FileVersion>
+        <PackageVersion>6.3.12</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/horse-framework/horse-messaging</PackageProjectUrl>

--- a/src/Horse.Messaging.Protocol/Horse.Messaging.Protocol.csproj
+++ b/src/Horse.Messaging.Protocol/Horse.Messaging.Protocol.csproj
@@ -7,9 +7,9 @@
         <Product>Horse.Messaging.Protocol</Product>
         <Description>Horse Messaging Protocol library and server extension for Horse Server</Description>
         <PackageTags>horse,tcp,server,http,messaging,queue,cache,channel,stream,protocol</PackageTags>
-        <AssemblyVersion>6.3.10</AssemblyVersion>
-        <FileVersion>6.3.10</FileVersion>
-        <PackageVersion>6.3.10</PackageVersion>
+        <AssemblyVersion>6.3.11</AssemblyVersion>
+        <FileVersion>6.3.11</FileVersion>
+        <PackageVersion>6.3.11</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/horse-framework/horse-messaging</PackageProjectUrl>

--- a/src/Horse.Messaging.Protocol/Horse.Messaging.Protocol.csproj
+++ b/src/Horse.Messaging.Protocol/Horse.Messaging.Protocol.csproj
@@ -7,9 +7,9 @@
         <Product>Horse.Messaging.Protocol</Product>
         <Description>Horse Messaging Protocol library and server extension for Horse Server</Description>
         <PackageTags>horse,tcp,server,http,messaging,queue,cache,channel,stream,protocol</PackageTags>
-        <AssemblyVersion>6.3.12</AssemblyVersion>
-        <FileVersion>6.3.12</FileVersion>
-        <PackageVersion>6.3.12</PackageVersion>
+        <AssemblyVersion>6.3.13</AssemblyVersion>
+        <FileVersion>6.3.13</FileVersion>
+        <PackageVersion>6.3.13</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/horse-framework/horse-messaging</PackageProjectUrl>

--- a/src/Horse.Messaging.Protocol/HorseResultCode.cs
+++ b/src/Horse.Messaging.Protocol/HorseResultCode.cs
@@ -228,6 +228,11 @@ namespace Horse.Messaging.Protocol
         /// <summary>
         /// Value size limit for message length etc
         /// </summary>
-        ValueSizeLimit = 702
+        ValueSizeLimit = 702,
+        
+        /// <summary>
+        /// No consumers
+        /// </summary>
+        NoConsumers = 703
     }
 }

--- a/src/Horse.Messaging.Server/Horse.Messaging.Server.csproj
+++ b/src/Horse.Messaging.Server/Horse.Messaging.Server.csproj
@@ -7,9 +7,9 @@
         <Product>Horse.Messaging.Server</Product>
         <Description>Horse Messaging Server</Description>
         <PackageTags>horse,server,messaging,queue,channel,cache</PackageTags>
-        <AssemblyVersion>6.3.10</AssemblyVersion>
-        <FileVersion>6.3.10</FileVersion>
-        <PackageVersion>6.3.10</PackageVersion>
+        <AssemblyVersion>6.3.11</AssemblyVersion>
+        <FileVersion>6.3.11</FileVersion>
+        <PackageVersion>6.3.11</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/horse-framework/horse-messaging</PackageProjectUrl>

--- a/src/Horse.Messaging.Server/Horse.Messaging.Server.csproj
+++ b/src/Horse.Messaging.Server/Horse.Messaging.Server.csproj
@@ -7,9 +7,9 @@
         <Product>Horse.Messaging.Server</Product>
         <Description>Horse Messaging Server</Description>
         <PackageTags>horse,server,messaging,queue,channel,cache</PackageTags>
-        <AssemblyVersion>6.3.12</AssemblyVersion>
-        <FileVersion>6.3.12</FileVersion>
-        <PackageVersion>6.3.12</PackageVersion>
+        <AssemblyVersion>6.3.13</AssemblyVersion>
+        <FileVersion>6.3.13</FileVersion>
+        <PackageVersion>6.3.13</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/horse-framework/horse-messaging</PackageProjectUrl>

--- a/src/Horse.Messaging.Server/Horse.Messaging.Server.csproj
+++ b/src/Horse.Messaging.Server/Horse.Messaging.Server.csproj
@@ -7,9 +7,9 @@
         <Product>Horse.Messaging.Server</Product>
         <Description>Horse Messaging Server</Description>
         <PackageTags>horse,server,messaging,queue,channel,cache</PackageTags>
-        <AssemblyVersion>6.3.11</AssemblyVersion>
-        <FileVersion>6.3.11</FileVersion>
-        <PackageVersion>6.3.11</PackageVersion>
+        <AssemblyVersion>6.3.12</AssemblyVersion>
+        <FileVersion>6.3.12</FileVersion>
+        <PackageVersion>6.3.12</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/horse-framework/horse-messaging</PackageProjectUrl>

--- a/src/Horse.Messaging.Server/Queues/Delivery/CommitWhen.cs
+++ b/src/Horse.Messaging.Server/Queues/Delivery/CommitWhen.cs
@@ -20,12 +20,6 @@ namespace Horse.Messaging.Server.Queues.Delivery
         AfterReceived,
 
         /// <summary>
-        /// After producer sent message and server saves it to disk
-        /// </summary>
-        [Description("after-saved")]
-        AfterSaved,
-
-        /// <summary>
         /// After message is sent to all consumers
         /// </summary>
         [Description("after-sent")]

--- a/src/Horse.Messaging.Server/Queues/HorseQueue.cs
+++ b/src/Horse.Messaging.Server/Queues/HorseQueue.cs
@@ -676,6 +676,10 @@ namespace Horse.Messaging.Server.Queues
 
                 return PushResult.Success;
             }
+            catch (DuplicateNameException)
+            {
+                return PushResult.DuplicateUniqueId;
+            }
             catch (Exception ex)
             {
                 Rider.SendError("PUSH", ex, $"QueueName:{Name}");
@@ -888,6 +892,10 @@ namespace Horse.Messaging.Server.Queues
 
                 return PushResult.Success;
             }
+            catch (DuplicateNameException)
+            {
+                return PushResult.DuplicateUniqueId;
+            }
             catch (Exception ex)
             {
                 Rider.SendError("PUSH", ex, $"QueueName:{Name}");
@@ -904,9 +912,9 @@ namespace Horse.Messaging.Server.Queues
                 catch //if developer does wrong operation, we should not stop
                 {
                 }
-            }
 
-            return PushResult.Success;
+                return PushResult.Error;
+            }
         }
 
         #endregion

--- a/src/Horse.Messaging.Server/Queues/HorseQueue.cs
+++ b/src/Horse.Messaging.Server/Queues/HorseQueue.cs
@@ -660,7 +660,7 @@ namespace Horse.Messaging.Server.Queues
                 message.Decision = decision;
                 Rider.Cluster.QueueUpdate = DateTime.UtcNow;
 
-                if (decision.Transmission == DecisionTransmission.Commit)
+                if (decision.Transmission != DecisionTransmission.Failed)
                 {
                     PushResult pushResult = AddMessage(message);
                     if (pushResult != PushResult.Success)

--- a/src/Horse.Messaging.Server/Queues/QueueMessageHandler.cs
+++ b/src/Horse.Messaging.Server/Queues/QueueMessageHandler.cs
@@ -98,17 +98,31 @@ namespace Horse.Messaging.Server.Queues
             PushResult result = await queue.Push(queueMessage, client);
             if (answerSender)
             {
-                if (result == PushResult.StatusNotSupported)
+                switch (result)
                 {
-                    await client.SendAsync(message.CreateResponse(HorseResultCode.Unacceptable));
-                }
-                else if (result == PushResult.LimitExceeded)
-                {
-                    await client.SendAsync(message.CreateResponse(HorseResultCode.LimitExceeded));
-                }
-                else if (result == PushResult.Error)
-                {
-                    await client.SendAsync(message.CreateResponse(HorseResultCode.Failed));
+                    case PushResult.Empty:
+                        await client.SendAsync(message.CreateResponse(HorseResultCode.NoContent));
+                        break;
+                    
+                    case PushResult.Error:
+                        await client.SendAsync(message.CreateResponse(HorseResultCode.Failed));
+                        break;
+                    
+                    case PushResult.LimitExceeded:
+                        await client.SendAsync(message.CreateResponse(HorseResultCode.LimitExceeded));
+                        break;
+                    
+                    case PushResult.NoConsumers:
+                        await client.SendAsync(message.CreateResponse(HorseResultCode.NoConsumers));
+                        break;
+                    
+                    case PushResult.DuplicateUniqueId:
+                        await client.SendAsync(message.CreateResponse(HorseResultCode.Duplicate));
+                        break;
+                    
+                    case PushResult.StatusNotSupported:
+                        await client.SendAsync(message.CreateResponse(HorseResultCode.Unacceptable));
+                        break;
                 }
             }
         }

--- a/src/Horse.Messaging.Server/Queues/QueueRider.cs
+++ b/src/Horse.Messaging.Server/Queues/QueueRider.cs
@@ -316,6 +316,10 @@ namespace Horse.Messaging.Server.Queues
                 if (initialize && queueManagerFactory != null)
                 {
                     IHorseQueueManager queueManager = await queueManagerFactory(handlerBuilder);
+                    
+                    if (requestMessage != null)
+                        queue.UpdateOptionsByMessage(requestMessage);
+
                     await queue.InitializeQueue(queueManager);
                 }
 

--- a/src/Samples/ClusteringSample.Server/Program.cs
+++ b/src/Samples/ClusteringSample.Server/Program.cs
@@ -30,7 +30,7 @@ namespace ClusteringSample.Server
                 {
                     q.Options.AcknowledgeTimeout = TimeSpan.FromSeconds(10);
                     q.Options.Acknowledge = QueueAckDecision.WaitForAcknowledge;
-                    q.Options.CommitWhen = CommitWhen.AfterSaved;
+                    q.Options.CommitWhen = CommitWhen.AfterReceived;
                     q.UsePersistentQueues(c =>
                     {
                         c.UseInstantFlush();

--- a/src/Samples/Sample.Consumer/ModelA.cs
+++ b/src/Samples/Sample.Consumer/ModelA.cs
@@ -1,15 +1,16 @@
 using System.Text.Json.Serialization;
 using Horse.Messaging.Client.Annotations;
 using Horse.Messaging.Client.Queues.Annotations;
+using Horse.Messaging.Protocol;
 using Newtonsoft.Json;
 using Sample.Producer;
 
 namespace Sample.Consumer
 {
-    [QueueName("model-a")]
+    [QueueName("model-g")]
     //[QueueStatus(MessagingQueueStatus.Push)]
+    [Acknowledge(QueueAckDecision.JustRequest)]
     [Interceptor(typeof(TestModelInterceptor1))]
-
     public class ModelA
     {
         [JsonProperty("no")]

--- a/src/Samples/Sample.Consumer/Program.cs
+++ b/src/Samples/Sample.Consumer/Program.cs
@@ -1,27 +1,45 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Horse.Messaging.Client;
+using Horse.Messaging.Client.Queues;
 
 namespace Sample.Consumer
 {
-	class Program
-	{
-		static void Main(string[] args)
-		{
-			HorseClientBuilder builder = new HorseClientBuilder();
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            HorseClientBuilder builder = new HorseClientBuilder();
 
-			HorseClient client = builder.AddHost("horse://localhost:26222")
-										.AddSingletonConsumers(typeof(Program))
-										 /*
-										.ConfigureModels(cfg => //cfg.UseQueueName(type => "Username1")
-															cfg.UseConsumerAck()
-															.AddMessageHeader("Sender-Client-Name", "MyName")
-															.SetPutBackDelay(TimeSpan.FromSeconds(10)))*/
-										.Build();
+            HorseClient client = builder.AddHost("horse://localhost:26222")
+                .AddSingletonConsumers(typeof(Program))
+                /*
+               .ConfigureModels(cfg => //cfg.UseQueueName(type => "Username1")
+                                   cfg.UseConsumerAck()
+                                   .AddMessageHeader("Sender-Client-Name", "MyName")
+                                   .SetPutBackDelay(TimeSpan.FromSeconds(10)))*/
+                .Build();
 
-			client.Connect();
+            client.Connect();
 
-			while (true)
-				Console.ReadLine();
-		}
-	}
+            var subs = await client.Queue.Subscribe("model-g", true);
+            Console.WriteLine("subs: " + subs.Code);
+
+            while (true)
+            {
+                await Task.Delay(250);
+                Console.ReadLine();
+                await Task.Delay(250);
+                var response = await client.Queue.Pull(new PullRequest
+                {
+                    Queue = "model-g",
+                    Count = 1,
+                    ClearAfter = ClearDecision.None,
+                    GetQueueMessageCounts = false,
+                    Order = MessageOrder.Default
+                }, async (i, message) => { await client.SendAck(message); });
+                Console.WriteLine($"pull response is {response.Status} and received {response.ReceivedCount} messages.");
+            }
+        }
+    }
 }

--- a/src/Samples/Sample.Producer/ModelA.cs
+++ b/src/Samples/Sample.Producer/ModelA.cs
@@ -7,9 +7,8 @@ using Newtonsoft.Json;
 
 namespace Sample.Producer
 {
-    [QueueName("model-a")]
-    [QueueManager("dhand")]
-    [QueueType(MessagingQueueType.Push)]
+    [QueueName("model-g")]
+    [QueueType(MessagingQueueType.Pull)]
     [Acknowledge(QueueAckDecision.JustRequest)]
     [Interceptor(typeof(TestModelInterceptor1))]
     public class ModelA

--- a/src/Samples/Sample.Producer/Program.cs
+++ b/src/Samples/Sample.Producer/Program.cs
@@ -73,7 +73,7 @@ namespace Sample.Producer
                 // var result = await client.Direct.RequestJson<ResponseModel>(new RequestModel());
                 // Console.WriteLine($"Push: {result.Code} ${JsonSerializer.Serialize(result.Model)}");
 
-                var result = await client.Queue.PushJson("SampleTestEvent", new TestEvent(), true);
+                var result = await client.Queue.PushJson("SampleTestEvent", new TestEvent(),"testId", true);
 
                 Console.WriteLine($"Push: {result.Code} {result.Reason} ${JsonSerializer.Serialize(result)}");
                 Console.ReadLine();

--- a/src/Samples/Sample.Producer/Program.cs
+++ b/src/Samples/Sample.Producer/Program.cs
@@ -45,25 +45,15 @@ namespace Sample.Producer
 
             ModelC c = new ModelC();
 
-            ModelA a = new ModelA();
-            a.Foo = "foo";
-            a.No = 123;
-
-            TestQuery query = new()
-            {
-                Foo = "Foo"
-            };
-            TestCommand command = new()
-            {
-                Foo = "Foo"
-            };
-            TestEvent @event = new()
-            {
-                Foo = "Foo"
-            };
-
             while (true)
             {
+                ModelA a = new ModelA();
+                a.Foo = "foo";
+                a.No = 123;
+
+                var result = await client.Queue.PushJson(a, true);
+                Console.WriteLine($"Push: {result.Code} {result.Reason}");
+                
                 // HorseResult result = await client.Router.PublishRequestJson<TestQuery, TestQueryResult>("test-service-route", query, 1);
                 // Console.WriteLine($"Push: {result.Code}");
 
@@ -72,10 +62,10 @@ namespace Sample.Producer
 
                 // var result = await client.Direct.RequestJson<ResponseModel>(new RequestModel());
                 // Console.WriteLine($"Push: {result.Code} ${JsonSerializer.Serialize(result.Model)}");
+/*
+                var result = await client.Queue.PushJson("SampleTestEvent", new TestEvent(), true);
 
-                var result = await client.Queue.PushJson("SampleTestEvent", new TestEvent(),"testId", true);
-
-                Console.WriteLine($"Push: {result.Code} {result.Reason} ${JsonSerializer.Serialize(result)}");
+                Console.WriteLine($"Push: {result.Code} {result.Reason} ${JsonSerializer.Serialize(result)}");*/
                 Console.ReadLine();
                 // await Task.Delay(5000);
             }

--- a/src/Samples/Sample.Server/Program.cs
+++ b/src/Samples/Sample.Server/Program.cs
@@ -18,18 +18,18 @@ namespace Sample.Server
                     cfg.Options.Type = QueueType.Push;
                     cfg.EventHandlers.Add(new QueueEventHandler());
 
-                    cfg.UseMemoryQueues(c =>
+                    /* cfg.UseMemoryQueues(c =>
                     {
                         c.Options.CommitWhen = CommitWhen.AfterReceived;
                         c.Options.Acknowledge = QueueAckDecision.WaitForAcknowledge;
                         c.Options.PutBack = PutBackDecision.Regular;
-                    });
-/*
+                    }); */
+                    
                     cfg.UsePersistentQueues(null, c =>
                     {
                         c.Options.Acknowledge = QueueAckDecision.WaitForAcknowledge;
-                        c.Options.CommitWhen = CommitWhen.AfterSaved;
-                    });*/
+                        c.Options.CommitWhen = CommitWhen.AfterReceived;
+                    });
                 })
                 .ConfigureClients(cfg => { cfg.Handlers.Add(new ClientHandler()); })
                 .Build();

--- a/src/Tests/Test.Queues/Types/PullTypeTest.cs
+++ b/src/Tests/Test.Queues/Types/PullTypeTest.cs
@@ -7,6 +7,7 @@ using Horse.Messaging.Client.Queues;
 using Horse.Messaging.Protocol;
 using Horse.Messaging.Server.Queues;
 using Horse.Messaging.Server.Queues.Delivery;
+using NuGet.Frameworks;
 using Test.Common;
 using Xunit;
 
@@ -133,7 +134,10 @@ namespace Test.Queues.Types
                 Count = count
             };
 
-            PullContainer container = await client.Queue.Pull(request);
+            int mx = 0;
+            PullContainer container = await client.Queue.Pull(request, async (i, m) => mx++);
+            await Task.Delay(100);
+            Assert.Equal(count, mx);
             Assert.Equal(count, container.ReceivedCount);
             Assert.Equal(PullProcess.Completed, container.Status);
             server.Stop();
@@ -189,7 +193,7 @@ namespace Test.Queues.Types
 
             if (messages)
                 Assert.Equal(0, queue.Manager.MessageStore.Count());
-            
+
             server.Stop();
         }
     }


### PR DESCRIPTION
- Duplicate message id tracking issue fixed while using customer message id generator
- Clients auto subscribes to pull states queue when a pull request has sent.
- Consuming one more message on pull queues bug fixed. Now only requested count will be consumed.
- Pull requests to empty queues freezing for a few seconds bug has fixed.
- BREAKING: AfterSaved Commit option removed. Use AfterReceived option. For persistent queues, AfterReceived does same operation with old AfterSaved option.
- BREAKING: Client side queue options priority issue has fixed. Now options by attributes has higher priority then server side default options in ConfigureQueues.