### PR TITLE
6.3.14

### DIFF
--- a/src/Benchmarks/Benchmark.Queue.Producer/Program.cs
+++ b/src/Benchmarks/Benchmark.Queue.Producer/Program.cs
@@ -44,6 +44,10 @@ namespace Benchmark.Queue.Producer
             string x = new string('a', 1);
             MemoryStream ms = new MemoryStream(Encoding.UTF8.GetBytes(x));
             client = new HorseClient();
+            client.Queue.SetOptions("fsd", o =>
+            {
+
+            });
 
             await client.ConnectAsync("horse://localhost:27001");
 

--- a/src/Benchmarks/Benchmark.Server/Program.cs
+++ b/src/Benchmarks/Benchmark.Server/Program.cs
@@ -1,7 +1,8 @@
 ﻿using System;
+using Horse.Messaging.Data;
+using Horse.Messaging.Protocol;
 using Horse.Messaging.Server;
 using Horse.Messaging.Server.Queues;
-using Horse.Messaging.Server.Queues.Delivery;
 using Horse.Server;
 
 namespace Benchmark.Server
@@ -16,10 +17,11 @@ namespace Benchmark.Server
                 .ConfigureQueues(cfg =>
                 {
                     cfg.EventHandlers.Add(new QueueEventHandler());
-                    //cfg.Options.Acknowledge = QueueAckDecision.None;
+                    cfg.Options.Acknowledge = QueueAckDecision.None;
                     cfg.Options.Type = QueueType.Push;
                     cfg.Options.AcknowledgeTimeout = TimeSpan.FromSeconds(30);
-                    cfg.UseMemoryQueues();
+                    //cfg.UseMemoryQueues();
+                    cfg.UsePersistentQueues(c => { c.UseAutoFlush(TimeSpan.FromMilliseconds(250)); });
                     //cfg.UseAckDeliveryHandler(AcknowledgeWhen.AfterReceived, PutBackDecision.No);
                 })
                 .ConfigureCache(cfg => { cfg.Options.DefaultDuration = TimeSpan.FromMinutes(30); })

--- a/src/Horse.Messaging.Client/Horse.Messaging.Client.csproj
+++ b/src/Horse.Messaging.Client/Horse.Messaging.Client.csproj
@@ -7,9 +7,9 @@
         <Product>Horse.Messaging.Client</Product>
         <Description>Horse Messaging Client to connect all Horse Servers</Description>
         <PackageTags>horse,client,messaging,queue,channel,cache</PackageTags>
-        <AssemblyVersion>6.3.13</AssemblyVersion>
-        <FileVersion>6.3.13</FileVersion>
-        <PackageVersion>6.3.13</PackageVersion>
+        <AssemblyVersion>6.3.14</AssemblyVersion>
+        <FileVersion>6.3.14</FileVersion>
+        <PackageVersion>6.3.14</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/horse-framework/horse-messaging</PackageProjectUrl>

--- a/src/Horse.Messaging.Client/Queues/Annotations/UniqueIdCheckAttribute.cs
+++ b/src/Horse.Messaging.Client/Queues/Annotations/UniqueIdCheckAttribute.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace Horse.Messaging.Client.Queues.Annotations;
+
+/// <summary>
+/// Used for unique message id checks
+/// </summary>
+[AttributeUsage(AttributeTargets.Class)]
+public class UniqueIdCheckAttribute : Attribute
+{
+    /// <summary>
+    /// If true, checks unique id
+    /// </summary>
+    public bool Value { get; set; }
+
+    /// <summary>
+    /// Used for unique message id checks
+    /// </summary>
+    public UniqueIdCheckAttribute() : this(true)
+    {
+    }
+
+    /// <summary>
+    /// Used for unique message id checks
+    /// </summary>
+    public UniqueIdCheckAttribute(bool value)
+    {
+        Value = value;
+    }
+}

--- a/src/Horse.Messaging.Client/Queues/QueueOptions.cs
+++ b/src/Horse.Messaging.Client/Queues/QueueOptions.cs
@@ -72,5 +72,12 @@ namespace Horse.Messaging.Client.Queues
         /// </summary>
         [JsonPropertyName("PutBackDelay")]
         public int? PutBackDelay { get; set; }
+        
+        /// <summary>
+        /// If true, server checks all message id values and reject new messages with same id.
+        /// Enabling that feature has performance penalty about 0.03 ms for each message. 
+        /// </summary>
+        [JsonPropertyName("MessageIdUniqueCheck")]
+        public bool? MessageIdUniqueCheck { get; set; }
     }
 }

--- a/src/Horse.Messaging.Client/Queues/QueueTypeDescriptor.cs
+++ b/src/Horse.Messaging.Client/Queues/QueueTypeDescriptor.cs
@@ -78,6 +78,12 @@ namespace Horse.Messaging.Client.Queues
         public int? AcknowledgeTimeout { get; set; }
 
         /// <summary>
+        /// If true, server checks all message id values and reject new messages with same id.
+        /// Enabling that feature has performance penalty about 0.03 ms for each message. 
+        /// </summary>
+        public bool? UniqueIdCheck { get; set; }
+
+        /// <summary>
         /// Creates new type delivery descriptor
         /// </summary>
         public QueueTypeDescriptor()
@@ -120,6 +126,9 @@ namespace Horse.Messaging.Client.Queues
 
             if (AcknowledgeTimeout.HasValue)
                 message.AddHeader(HorseHeaders.ACK_TIMEOUT, AcknowledgeTimeout.Value.ToString());
+
+            if (UniqueIdCheck.HasValue)
+                message.AddHeader(HorseHeaders.MESSAGE_ID_UNIQUE_CHECK, UniqueIdCheck.Value ? "1" : "0");
 
             foreach (KeyValuePair<string, string> pair in Headers)
                 message.AddHeader(pair.Key, pair.Value);

--- a/src/Horse.Messaging.Client/Queues/QueueTypeResolver.cs
+++ b/src/Horse.Messaging.Client/Queues/QueueTypeResolver.cs
@@ -115,6 +115,10 @@ namespace Horse.Messaging.Client.Queues
             if (topicAttr != null)
                 descriptor.Topic = topicAttr.Topic;
 
+            UniqueIdCheckAttribute uidAttr = type.GetCustomAttribute<UniqueIdCheckAttribute>(true);
+            if (uidAttr != null)
+                descriptor.UniqueIdCheck = uidAttr.Value;
+            
             MessageTimeoutAttribute msgTimeoutAttr = type.GetCustomAttribute<MessageTimeoutAttribute>(true);
             if (msgTimeoutAttr != null)
                 descriptor.MessageTimeout = msgTimeoutAttr.Value;

--- a/src/Horse.Messaging.Data/Horse.Messaging.Data.csproj
+++ b/src/Horse.Messaging.Data/Horse.Messaging.Data.csproj
@@ -7,9 +7,9 @@
         <Product>Horse.Messaging.Data</Product>
         <Description>Persistant queue message data library for Horse Messaging</Description>
         <PackageTags>horse,server,messaging,queue,mq,persistent,database,db</PackageTags>
-        <AssemblyVersion>6.3.13</AssemblyVersion>
-        <FileVersion>6.3.13</FileVersion>
-        <PackageVersion>6.3.13</PackageVersion>
+        <AssemblyVersion>6.3.14</AssemblyVersion>
+        <FileVersion>6.3.14</FileVersion>
+        <PackageVersion>6.3.14</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/horse-framework/horse-messaging</PackageProjectUrl>

--- a/src/Horse.Messaging.Data/Implementation/PersistentMessageStore.cs
+++ b/src/Horse.Messaging.Data/Implementation/PersistentMessageStore.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Horse.Messaging.Protocol;
 using Horse.Messaging.Server.Queues;
@@ -10,7 +10,7 @@ namespace Horse.Messaging.Data.Implementation
     /// <summary>
     /// Message store object for persistent queues
     /// </summary>
-    public class PersistentMessageStore : DictionaryMessageStore
+    public class PersistentMessageStore : LinkedMessageStore
     {
         internal Database Database { get; }
 
@@ -26,7 +26,7 @@ namespace Horse.Messaging.Data.Implementation
         /// <summary>
         /// Initializes the store, opens the database file.
         /// </summary>
-        public Task Initialize()
+        public Task<List<HorseMessage>> Initialize()
         {
             return Database.Open();
         }
@@ -66,7 +66,7 @@ namespace Horse.Messaging.Data.Implementation
         {
             base.Remove(message);
         }
-        
+
         /// <summary>
         /// Remoes the message from disk and queue
         /// </summary>

--- a/src/Horse.Messaging.Extensions.Client/Horse.Messaging.Extensions.Client.csproj
+++ b/src/Horse.Messaging.Extensions.Client/Horse.Messaging.Extensions.Client.csproj
@@ -7,9 +7,9 @@
         <Product>Horse.Messaging.Data</Product>
         <Description>Horse messaging extensions library</Description>
         <PackageTags>horse,server,messaging,queue,mq,persistent,database,db</PackageTags>
-        <AssemblyVersion>6.3.13</AssemblyVersion>
-        <FileVersion>6.3.13</FileVersion>
-        <PackageVersion>6.3.13</PackageVersion>
+        <AssemblyVersion>6.3.14</AssemblyVersion>
+        <FileVersion>6.3.14</FileVersion>
+        <PackageVersion>6.3.14</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/horse-framework/horse-messaging</PackageProjectUrl>

--- a/src/Horse.Messaging.Protocol/Horse.Messaging.Protocol.csproj
+++ b/src/Horse.Messaging.Protocol/Horse.Messaging.Protocol.csproj
@@ -7,9 +7,9 @@
         <Product>Horse.Messaging.Protocol</Product>
         <Description>Horse Messaging Protocol library and server extension for Horse Server</Description>
         <PackageTags>horse,tcp,server,http,messaging,queue,cache,channel,stream,protocol</PackageTags>
-        <AssemblyVersion>6.3.13</AssemblyVersion>
-        <FileVersion>6.3.13</FileVersion>
-        <PackageVersion>6.3.13</PackageVersion>
+        <AssemblyVersion>6.3.14</AssemblyVersion>
+        <FileVersion>6.3.14</FileVersion>
+        <PackageVersion>6.3.14</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/horse-framework/horse-messaging</PackageProjectUrl>

--- a/src/Horse.Messaging.Protocol/HorseHeaders.cs
+++ b/src/Horse.Messaging.Protocol/HorseHeaders.cs
@@ -310,5 +310,10 @@ namespace Horse.Messaging.Protocol
         /// </summary>
         public const string REPLICA_NODE = "Replica-Node";
 
+        /// <summary>
+        /// "Message-Id-Unique-Check"
+        /// </summary>
+        public const string MESSAGE_ID_UNIQUE_CHECK = "Message-Id-Unique-Check";
+
     }
 }

--- a/src/Horse.Messaging.Server/Cluster/NodeClient.cs
+++ b/src/Horse.Messaging.Server/Cluster/NodeClient.cs
@@ -411,7 +411,7 @@ namespace Horse.Messaging.Server.Cluster
                     HorseQueue queue = Rider.Queue.Find(message.Target);
 
                     if (queue != null)
-                        _ = queue.Manager.RemoveMessage(message.MessageId);
+                        _ = queue.RemoveMessage(message.MessageId);
 
                     break;
                 }

--- a/src/Horse.Messaging.Server/Cluster/NodeQueueInfo.cs
+++ b/src/Horse.Messaging.Server/Cluster/NodeQueueInfo.cs
@@ -29,5 +29,8 @@
         public int DelayBetweenMessages { get; set; }
         public ulong MessageSizeLimit { get; set; }
         public int PutBackDelay { get; set; }
+        
+        public bool MessageIdUniqueCheck { get; set; }
+
     }
 }

--- a/src/Horse.Messaging.Server/Horse.Messaging.Server.csproj
+++ b/src/Horse.Messaging.Server/Horse.Messaging.Server.csproj
@@ -7,9 +7,9 @@
         <Product>Horse.Messaging.Server</Product>
         <Description>Horse Messaging Server</Description>
         <PackageTags>horse,server,messaging,queue,channel,cache</PackageTags>
-        <AssemblyVersion>6.3.13</AssemblyVersion>
-        <FileVersion>6.3.13</FileVersion>
-        <PackageVersion>6.3.13</PackageVersion>
+        <AssemblyVersion>6.3.14</AssemblyVersion>
+        <FileVersion>6.3.14</FileVersion>
+        <PackageVersion>6.3.14</PackageVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mehmet Helvacıköylü;Emre Hızlı</Authors>
         <PackageProjectUrl>https://github.com/horse-framework/horse-messaging</PackageProjectUrl>

--- a/src/Horse.Messaging.Server/Queues/HorseQueue.cs
+++ b/src/Horse.Messaging.Server/Queues/HorseQueue.cs
@@ -976,7 +976,6 @@ namespace Horse.Messaging.Server.Queues
                     Info.AddMessageRemove();
                     await Manager.RemoveMessage(message);
                     message.MarkAsRemoved();
-
                     if (Rider.Cluster.State == NodeState.Main && Rider.Cluster.Options.Mode == ClusterMode.Reliable)
                         Rider.Cluster.SendMessageRemoval(this, message.Message);
                 }

--- a/src/Horse.Messaging.Server/Queues/Managers/MemoryQueueManager.cs
+++ b/src/Horse.Messaging.Server/Queues/Managers/MemoryQueueManager.cs
@@ -33,8 +33,8 @@ namespace Horse.Messaging.Server.Queues.Managers
         {
             Queue = queue;
 
-            MessageStore = new DictionaryMessageStore(this);
-            PriorityMessageStore = new DictionaryMessageStore(this);
+            MessageStore = new LinkedMessageStore(this);
+            PriorityMessageStore = new LinkedMessageStore(this);
             Synchronizer = new DefaultQueueSynchronizer(this);
             DeliveryHandler = new MemoryDeliveryHandler(this);
         }

--- a/src/Horse.Messaging.Server/Queues/NetworkOptionsBuilder.cs
+++ b/src/Horse.Messaging.Server/Queues/NetworkOptionsBuilder.cs
@@ -84,6 +84,13 @@ namespace Horse.Messaging.Server.Queues
         [JsonPropertyName("PutBackDelay")]
         public int? PutBackDelay { get; set; }
 
+        /// <summary>
+        /// If true, server checks all message id values and reject new messages with same id.
+        /// Enabling that feature has performance penalty about 0.03 ms for each message. 
+        /// </summary>
+        [JsonPropertyName("MessageIdUniqueCheck")]
+        public bool? MessageIdUniqueCheck { get; set; }
+
         #endregion
 
         #region Apply
@@ -122,6 +129,9 @@ namespace Horse.Messaging.Server.Queues
 
             if (PutBackDelay.HasValue)
                 target.PutBackDelay = PutBackDelay.Value;
+
+            if (MessageIdUniqueCheck.HasValue)
+                target.MessageIdUniqueCheck = MessageIdUniqueCheck.Value;
         }
 
         #endregion

--- a/src/Horse.Messaging.Server/Queues/QueueConfiguration.cs
+++ b/src/Horse.Messaging.Server/Queues/QueueConfiguration.cs
@@ -106,6 +106,12 @@ public class QueueConfiguration
     public string AutoDestroy { get; set; }
     
     /// <summary>
+    /// If true, server checks all message id values and reject new messages with same id.
+    /// Enabling that feature has performance penalty about 0.03 ms for each message. 
+    /// </summary>
+    public bool MessageIdUniqueCheck { get; set; }
+    
+    /// <summary>
     /// Creates new queue configuration from queue
     /// </summary>
     public static QueueConfiguration Create(HorseQueue queue)
@@ -129,7 +135,8 @@ public class QueueConfiguration
             DelayBetweenMessages = queue.Options.DelayBetweenMessages,
             PutBackDelay = queue.Options.PutBackDelay,
             MessageSizeLimit = queue.Options.MessageSizeLimit,
-            MessageTimeout = Convert.ToInt64(queue.Options.AcknowledgeTimeout.TotalMilliseconds)
+            MessageTimeout = Convert.ToInt64(queue.Options.AcknowledgeTimeout.TotalMilliseconds),
+            MessageIdUniqueCheck = queue.Options.MessageIdUniqueCheck
         };
     }
 }

--- a/src/Horse.Messaging.Server/Queues/QueueFiller.cs
+++ b/src/Horse.Messaging.Server/Queues/QueueFiller.cs
@@ -39,7 +39,7 @@ namespace Horse.Messaging.Server.Queues
                     {
                         QueueMessage firstMessage = _queue.Manager.MessageStore.ConsumeFirst();
                         if (firstMessage != null)
-                            _queue.Manager.RemoveMessage(firstMessage).GetAwaiter().GetResult();
+                            _queue.RemoveMessage(firstMessage).GetAwaiter().GetResult();
                     }
                     else
                         return PushResult.LimitExceeded;
@@ -91,7 +91,7 @@ namespace Horse.Messaging.Server.Queues
                     {
                         QueueMessage firstMessage = _queue.Manager.MessageStore.ConsumeFirst();
                         if (firstMessage != null)
-                            _queue.Manager.RemoveMessage(firstMessage).GetAwaiter().GetResult();
+                            _queue.RemoveMessage(firstMessage).GetAwaiter().GetResult();
                     }
                     else
                         return PushResult.LimitExceeded;
@@ -142,7 +142,7 @@ namespace Horse.Messaging.Server.Queues
                     {
                         QueueMessage firstMessage = _queue.Manager.MessageStore.ConsumeFirst();
                         if (firstMessage != null)
-                            _queue.Manager.RemoveMessage(firstMessage).GetAwaiter().GetResult();
+                            _queue.RemoveMessage(firstMessage).GetAwaiter().GetResult();
                     }
                     else
                         return PushResult.LimitExceeded;
@@ -195,7 +195,7 @@ namespace Horse.Messaging.Server.Queues
                     {
                         QueueMessage firstMessage = _queue.Manager.MessageStore.ConsumeFirst();
                         if (firstMessage != null)
-                            _queue.Manager.RemoveMessage(firstMessage).GetAwaiter().GetResult();
+                            _queue.RemoveMessage(firstMessage).GetAwaiter().GetResult();
                     }
                     else
                         return PushResult.LimitExceeded;
@@ -248,7 +248,7 @@ namespace Horse.Messaging.Server.Queues
                     {
                         QueueMessage firstMessage = _queue.Manager.MessageStore.ConsumeFirst();
                         if (firstMessage != null)
-                            _queue.Manager.RemoveMessage(firstMessage).GetAwaiter().GetResult();
+                            _queue.RemoveMessage(firstMessage).GetAwaiter().GetResult();
                     }
                     else
                         return PushResult.LimitExceeded;

--- a/src/Horse.Messaging.Server/Queues/QueueOptions.cs
+++ b/src/Horse.Messaging.Server/Queues/QueueOptions.cs
@@ -87,6 +87,12 @@ namespace Horse.Messaging.Server.Queues
         public bool AutoQueueCreation { get; set; } = true;
 
         /// <summary>
+        /// If true, server checks all message id values and reject new messages with same id.
+        /// Enabling that feature has performance penalty about 0.03 ms for each message. 
+        /// </summary>
+        public bool MessageIdUniqueCheck { get; set; }
+
+        /// <summary>
         /// Creates clone of the object
         /// </summary>
         /// <returns></returns>
@@ -115,7 +121,8 @@ namespace Horse.Messaging.Server.Queues
                 ClientLimit = options.ClientLimit,
                 CommitWhen = options.CommitWhen,
                 PutBack = options.PutBack,
-                AutoQueueCreation = options.AutoQueueCreation
+                AutoQueueCreation = options.AutoQueueCreation,
+                MessageIdUniqueCheck = options.MessageIdUniqueCheck
             };
         }
     }

--- a/src/Horse.Messaging.Server/Queues/QueueRider.cs
+++ b/src/Horse.Messaging.Server/Queues/QueueRider.cs
@@ -133,7 +133,8 @@ namespace Horse.Messaging.Server.Queues
                         DelayBetweenMessages = configuration.DelayBetweenMessages,
                         LimitExceededStrategy = Enums.Parse<MessageLimitExceededStrategy>(configuration.LimitExceededStrategy, true, EnumFormat.Description),
                         MessageSizeLimit = configuration.MessageSizeLimit,
-                        PutBackDelay = configuration.PutBackDelay
+                        PutBackDelay = configuration.PutBackDelay,
+                        MessageIdUniqueCheck = configuration.MessageIdUniqueCheck
                     };
 
                     QueueStatus status = Enums.Parse<QueueStatus>(configuration.Status, true, EnumFormat.Description);
@@ -382,6 +383,7 @@ namespace Horse.Messaging.Server.Queues
             options.ClientLimit = info.ClientLimit;
             options.MessageLimit = info.MessageLimit;
             options.MessageSizeLimit = info.MessageSizeLimit;
+            options.MessageIdUniqueCheck = info.MessageIdUniqueCheck;
 
             if (!string.IsNullOrEmpty(info.LimitExceededStrategy))
                 options.LimitExceededStrategy = Enums.Parse<MessageLimitExceededStrategy>(info.LimitExceededStrategy, true, EnumFormat.Description);

--- a/src/Horse.Messaging.Server/Queues/States/PushQueueState.cs
+++ b/src/Horse.Messaging.Server/Queues/States/PushQueueState.cs
@@ -60,7 +60,7 @@ namespace Horse.Messaging.Server.Queues.States
                 PushResult pushResult = _queue.AddMessage(message, false);
                 if (pushResult != PushResult.Success)
                     return pushResult;
-                
+
                 return PushResult.NoConsumers;
             }
 
@@ -134,7 +134,7 @@ namespace Horse.Messaging.Server.Queues.States
 
             message.Decision = await deliveryHandler.EndSend(_queue, message);
             await _queue.ApplyDecision(message.Decision, message);
-
+            
             return PushResult.Success;
         }
 

--- a/src/Horse.Messaging.Server/Queues/Store/LinkedMessageStore.cs
+++ b/src/Horse.Messaging.Server/Queues/Store/LinkedMessageStore.cs
@@ -13,7 +13,7 @@ namespace Horse.Messaging.Server.Queues.Store
     {
         /// <inheritdoc />
         public IHorseQueueManager Manager { get; }
-        
+
         /// <inheritdoc />
         public IMessageTimeoutTracker TimeoutTracker { get; }
 
@@ -115,7 +115,7 @@ namespace Horse.Messaging.Server.Queues.Store
                         continue;
 
                     message.IsInQueue = false;
-                    
+
                     list.Add(message);
                     _messages.RemoveFirst();
                 }
@@ -175,8 +175,9 @@ namespace Horse.Messaging.Server.Queues.Store
         /// <inheritdoc />
         public virtual void Remove(QueueMessage message)
         {
-            lock (_messages)
-                _messages.Remove(message);
+            if (message.IsInQueue)
+                lock (_messages)
+                    _messages.Remove(message);
         }
 
         /// <inheritdoc />
@@ -184,7 +185,7 @@ namespace Horse.Messaging.Server.Queues.Store
         {
             lock (_messages)
                 _messages.Clear();
-            
+
             return Task.CompletedTask;
         }
 

--- a/src/Horse.Messaging.Server/Queues/Store/MessageEqualityComparer.cs
+++ b/src/Horse.Messaging.Server/Queues/Store/MessageEqualityComparer.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Horse.Messaging.Server.Queues.Store;
+
+public class MessageEqualityComparer : IEqualityComparer<QueueMessage>
+{
+    public bool Equals(QueueMessage x, QueueMessage y)
+    {
+        if (x.Message?.MessageId == null) return false;
+        if (y.Message?.MessageId == null) return false;
+
+        return x.Message.MessageId.Equals(y.Message.MessageId);
+    }
+
+    public int GetHashCode(QueueMessage obj)
+    {
+        var hashCode = new HashCode();
+        hashCode.Add(obj.Message.MessageId);
+        return hashCode.ToHashCode();
+    }
+}

--- a/src/Horse.Messaging.Server/Queues/Sync/DefaultQueueSynchronizer.cs
+++ b/src/Horse.Messaging.Server/Queues/Sync/DefaultQueueSynchronizer.cs
@@ -220,7 +220,7 @@ namespace Horse.Messaging.Server.Queues.Sync
             }
 
             foreach (QueueMessage msg in removing)
-                await Manager.RemoveMessage(msg);
+                await Manager.Queue.RemoveMessage(msg);
 
             if (requestMessages.Count == 0)
             {

--- a/src/Samples/Sample.Consumer/Program.cs
+++ b/src/Samples/Sample.Consumer/Program.cs
@@ -30,6 +30,7 @@ namespace Sample.Consumer
                 await Task.Delay(250);
                 Console.ReadLine();
                 await Task.Delay(250);
+                
                 var response = await client.Queue.Pull(new PullRequest
                 {
                     Queue = "model-g",
@@ -37,7 +38,11 @@ namespace Sample.Consumer
                     ClearAfter = ClearDecision.None,
                     GetQueueMessageCounts = false,
                     Order = MessageOrder.Default
-                }, async (i, message) => { await client.SendAck(message); });
+                }, async (i, message) =>
+                {
+                    await client.SendAck(message);
+                });
+                
                 Console.WriteLine($"pull response is {response.Status} and received {response.ReceivedCount} messages.");
             }
         }


### PR DESCRIPTION
- Queue message consume performance increased.
- Persistent queue produce and consume performance (both cpu and memory usage) is increased.
- Unique message id check system now optional. You can enable/disable it from QueueOptions. Enabling that option has a performance penaltly about 0.03ms (30 microseconds) for each message.
- Some pull state queue issues are fixed.