### PR TITLE
feat(partitions): consumer-declared capacity works regardless of part…

### DIFF
--- a/src/Horse.Messaging.Server/Queues/Partitions/PartitionManager.cs
+++ b/src/Horse.Messaging.Server/Queues/Partitions/PartitionManager.cs
@@ -55,6 +55,14 @@ public class PartitionManager
     /// </summary>
     private readonly ConcurrentDictionary<string, HashSet<string>> _partitionSubscribers = new();
 
+    /// <summary>
+    /// Remembers the last subscribers-per-partition value consumers explicitly declared per label.
+    /// Consulted when a label partition is (re)created without an override — e.g. publisher-first
+    /// creation after idle auto-destroy — so the partition keeps the capacity its consumers declared
+    /// instead of falling back to the server default. Value 0 means unlimited.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, int> _labelDesiredSubscribers = new(StringComparer.OrdinalIgnoreCase);
+
     /// <summary>All active partition entries (snapshot).</summary>
     public IEnumerable<PartitionEntry> Partitions => _partitions.Values;
 
@@ -97,9 +105,20 @@ public class PartitionManager
 
         if (!string.IsNullOrEmpty(partitionLabel))
         {
+            // Remember the declared capacity so publisher-first re-creations of this
+            // label partition (after auto-destroy) keep the same capacity.
+            if (subscribersOverride.HasValue && subscribersOverride.Value >= 0)
+                _labelDesiredSubscribers[partitionLabel] = subscribersOverride.Value;
+
             entry = await GetOrCreateLabelPartition(partitionLabel, subscribersOverride);
             if (entry == null)
                 return null;
+
+            // The partition may exist from a publisher-first creation with default capacity.
+            // A consumer declaring a higher capacity upgrades the live partition; live
+            // partitions are never shrunk (connected subscribers must not be orphaned).
+            if (subscribersOverride.HasValue)
+                UpgradePartitionCapacity(entry, subscribersOverride.Value);
 
             SubscriptionResult result = await entry.Queue.AddClient(client);
             if (result == SubscriptionResult.Full)
@@ -197,7 +216,7 @@ public class PartitionManager
             entry.LastMessageAt = DateTime.UtcNow;
 
             // Auto-assign: if partition has fewer consumers than allowed, pull one from the worker pool
-            if (_options.AutoAssignWorkers && target.Clients.Count() < _options.SubscribersPerPartition)
+            if (_options.AutoAssignWorkers && HasSubscriberRoom(entry))
                 await TryAssignPooledWorker(entry);
         }
         else
@@ -302,9 +321,15 @@ public class PartitionManager
             }
 
             QueueOptions partitionOptions = QueueOptions.CloneFrom(_parentQueue.Options);
-            int effectiveSubscribers = subscribersOverride.HasValue && subscribersOverride.Value >= 0
-                ? subscribersOverride.Value
-                : _options.SubscribersPerPartition;
+            int effectiveSubscribers;
+            if (subscribersOverride.HasValue && subscribersOverride.Value >= 0)
+                effectiveSubscribers = subscribersOverride.Value;
+            // Publisher-first creation carries no override; prefer the capacity consumers
+            // last declared for this label over the server default.
+            else if (!string.IsNullOrEmpty(label) && _labelDesiredSubscribers.TryGetValue(label, out int remembered))
+                effectiveSubscribers = remembered;
+            else
+                effectiveSubscribers = _options.SubscribersPerPartition;
             partitionOptions.ClientLimit = effectiveSubscribers;
             partitionOptions.AutoQueueCreation = false;
             partitionOptions.Partition = null; // Prevent recursive partitioning
@@ -425,7 +450,7 @@ public class PartitionManager
             if (_availableWorkers.IsEmpty)
                 break;
 
-            while (entry.Queue.Clients.Count() < _options.SubscribersPerPartition)
+            while (HasSubscriberRoom(entry))
             {
                 if (_availableWorkers.IsEmpty)
                     break;
@@ -443,6 +468,42 @@ public class PartitionManager
     #endregion
 
     #region Helpers
+
+    /// <summary>
+    /// True when the partition queue can accept another consumer.
+    /// Uses the partition's own client limit (creation-time capacity, possibly upgraded by a
+    /// consumer declaration) instead of the parent-level default; 0 means unlimited.
+    /// </summary>
+    private static bool HasSubscriberRoom(PartitionEntry entry)
+    {
+        if (entry.Queue == null)
+            return false;
+
+        int limit = entry.Queue.Options.ClientLimit;
+        return limit == 0 || entry.Queue.Clients.Count() < limit;
+    }
+
+    /// <summary>
+    /// Raises the live partition queue's client limit when a consumer declares a higher
+    /// subscribers-per-partition than the partition was created with. Never shrinks a live
+    /// partition (connected subscribers must not be orphaned); a lower declaration only takes
+    /// effect on the next re-creation via the remembered label capacity. 0 means unlimited.
+    /// </summary>
+    private static void UpgradePartitionCapacity(PartitionEntry entry, int declaredSubscribers)
+    {
+        if (declaredSubscribers < 0 || entry.Queue == null)
+            return;
+
+        int current = entry.Queue.Options.ClientLimit;
+        if (current == 0)
+            return;
+
+        if (declaredSubscribers == 0 || declaredSubscribers > current)
+        {
+            entry.Queue.Options.ClientLimit = declaredSubscribers;
+            entry.Queue.EnsureClientCapacity();
+        }
+    }
 
     /// <summary>
     /// Records a worker as a subscriber of the given partition.
@@ -595,7 +656,7 @@ public class PartitionManager
 
         // Collect partitions that need consumers, sorted by consumer count ascending (least-loaded first)
         List<PartitionEntry> starved = _partitions.Values
-            .Where(e => e.Queue.Clients.Count() < _options.SubscribersPerPartition)
+            .Where(HasSubscriberRoom)
             .OrderBy(e => e.Queue.Clients.Count())
             .ToList();
 

--- a/src/Tests/Test.Queues/Partitions/PartitionPublisherFirstCapacityTest.cs
+++ b/src/Tests/Test.Queues/Partitions/PartitionPublisherFirstCapacityTest.cs
@@ -1,0 +1,210 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Horse.Messaging.Client;
+using Horse.Messaging.Protocol;
+using Horse.Messaging.Server.Queues;
+using Horse.Messaging.Server.Queues.Partitions;
+using Test.Common;
+using Xunit;
+
+namespace Test.Queues.Partitions;
+
+/// <summary>
+/// Tests that consumer-declared subscribers-per-partition capacity works regardless of
+/// which side created the label partition first. A partition created publisher-first
+/// (push with PARTITION_LABEL before any consumer subscribed — e.g. after idle auto-destroy)
+/// used to be locked to the server default capacity, rejecting every consumer beyond the
+/// first with LimitExceeded. Consumers must be able to upgrade a live partition's capacity,
+/// and the last declared capacity per label must be remembered for future re-creations.
+/// </summary>
+public class PartitionPublisherFirstCapacityTest
+{
+    private static Task CreatePartitionedQueue(TestHorseRider server, string name, int autoDestroyIdleSeconds)
+    {
+        return server.Rider.Queue.Create(name, opts =>
+        {
+            opts.Type = QueueType.RoundRobin;
+            opts.Acknowledge = QueueAckDecision.WaitForAcknowledge;
+            opts.Partition = new PartitionOptions
+            {
+                Enabled = true,
+                MaxPartitionCount = 0,
+                MaxPartitionsPerWorker = 1,
+                SubscribersPerPartition = 1,
+                AutoAssignWorkers = true,
+                AutoDestroy = PartitionAutoDestroy.NoMessages,
+                AutoDestroyIdleSeconds = autoDestroyIdleSeconds
+            };
+        });
+    }
+
+    [Fact]
+    public async Task PublisherFirst_ConsumerOverride_UpgradesLivePartition_AllSubscribe()
+    {
+        await TestHorseRider.RunWith(async (server, port) =>
+        {
+            await CreatePartitionedQueue(server, "pf-upgrade-q", 60);
+
+            // Publisher creates the label partition first — capacity falls back to server default (1)
+            HorseClient producer = new HorseClient();
+            await producer.ConnectAsync("horse://localhost:" + port);
+            await producer.Queue.Push("pf-upgrade-q", Encoding.UTF8.GetBytes("msg"), false,
+                new[] { new KeyValuePair<string, string>(HorseHeaders.PARTITION_LABEL, "premium") }, CancellationToken.None);
+
+            await Task.Delay(300);
+
+            HorseQueue queue = server.Rider.Queue.Find("pf-upgrade-q");
+            PartitionEntry entry = queue.PartitionManager.Partitions.FirstOrDefault(p => p.Label == "premium");
+            Assert.NotNull(entry);
+            Assert.Equal(1, entry.Queue.Options.ClientLimit);
+
+            // Three consumers declare capacity 64 — all must join the existing partition
+            for (int i = 0; i < 3; i++)
+            {
+                HorseClient consumer = new HorseClient();
+                await consumer.ConnectAsync("horse://localhost:" + port);
+                HorseResult result = await consumer.Queue.SubscribePartitioned("pf-upgrade-q", "premium", true, 0, 64, CancellationToken.None);
+                Assert.Equal(HorseResultCode.Ok, result.Code);
+            }
+
+            await Task.Delay(300);
+
+            Assert.Equal(64, entry.Queue.Options.ClientLimit);
+            Assert.Equal(3, entry.Queue.ClientsCount());
+        });
+    }
+
+    [Fact]
+    public async Task RecreateAfterDestroy_UsesRememberedLabelCapacity_And_ReassignsPooledWorkers()
+    {
+        await TestHorseRider.RunWith(async (server, port) =>
+        {
+            await CreatePartitionedQueue(server, "pf-remember-q", 1);
+
+            // Consumers declare capacity 8 (consumer-first creation)
+            HorseClient c1 = new HorseClient();
+            await c1.ConnectAsync("horse://localhost:" + port);
+            HorseResult r1 = await c1.Queue.SubscribePartitioned("pf-remember-q", "premium", true, 0, 8, CancellationToken.None);
+            Assert.Equal(HorseResultCode.Ok, r1.Code);
+
+            HorseClient c2 = new HorseClient();
+            await c2.ConnectAsync("horse://localhost:" + port);
+            HorseResult r2 = await c2.Queue.SubscribePartitioned("pf-remember-q", "premium", true, 0, 8, CancellationToken.None);
+            Assert.Equal(HorseResultCode.Ok, r2.Code);
+
+            HorseQueue queue = server.Rider.Queue.Find("pf-remember-q");
+
+            // Empty partition is auto-destroyed (NoMessages, 1s timer); workers return to the pool
+            await Task.Delay(3000);
+            Assert.Null(queue.PartitionManager.Partitions.FirstOrDefault(p => p.Label == "premium"));
+
+            // Publisher re-creates the partition — remembered capacity (8) must win over default (1)
+            HorseClient producer = new HorseClient();
+            await producer.ConnectAsync("horse://localhost:" + port);
+            await producer.Queue.Push("pf-remember-q", Encoding.UTF8.GetBytes("m1"), false,
+                new[] { new KeyValuePair<string, string>(HorseHeaders.PARTITION_LABEL, "premium") }, CancellationToken.None);
+            await producer.Queue.Push("pf-remember-q", Encoding.UTF8.GetBytes("m2"), false,
+                new[] { new KeyValuePair<string, string>(HorseHeaders.PARTITION_LABEL, "premium") }, CancellationToken.None);
+
+            await Task.Delay(500);
+
+            PartitionEntry recreated = queue.PartitionManager.Partitions.FirstOrDefault(p => p.Label == "premium");
+            Assert.NotNull(recreated);
+            Assert.Equal(8, recreated.Queue.Options.ClientLimit);
+
+            // Both pooled workers must be re-assigned (old behaviour capped auto-assign at the
+            // parent-level default of 1 subscriber even when the partition had more capacity)
+            Assert.Equal(2, recreated.Queue.ClientsCount());
+        });
+    }
+
+    [Fact]
+    public async Task PublisherFirst_NoConsumerDeclaration_KeepsServerDefault()
+    {
+        await TestHorseRider.RunWith(async (server, port) =>
+        {
+            await CreatePartitionedQueue(server, "pf-tenant-q", 60);
+
+            // Publisher-first creation for a tenant label
+            HorseClient producer = new HorseClient();
+            await producer.ConnectAsync("horse://localhost:" + port);
+            await producer.Queue.Push("pf-tenant-q", Encoding.UTF8.GetBytes("msg"), false,
+                new[] { new KeyValuePair<string, string>(HorseHeaders.PARTITION_LABEL, "tenant-a") }, CancellationToken.None);
+
+            await Task.Delay(300);
+
+            // First consumer without a capacity declaration joins
+            HorseClient c1 = new HorseClient();
+            await c1.ConnectAsync("horse://localhost:" + port);
+            HorseResult r1 = await c1.Queue.Subscribe("pf-tenant-q", true,
+                new[] { new KeyValuePair<string, string>(HorseHeaders.PARTITION_LABEL, "tenant-a") }, CancellationToken.None);
+            Assert.Equal(HorseResultCode.Ok, r1.Code);
+
+            // Second consumer without declaration is rejected — tenant isolation intact
+            HorseClient c2 = new HorseClient();
+            await c2.ConnectAsync("horse://localhost:" + port);
+            HorseResult r2 = await c2.Queue.Subscribe("pf-tenant-q", true,
+                new[] { new KeyValuePair<string, string>(HorseHeaders.PARTITION_LABEL, "tenant-a") }, CancellationToken.None);
+            Assert.Equal(HorseResultCode.LimitExceeded, r2.Code);
+
+            HorseQueue queue = server.Rider.Queue.Find("pf-tenant-q");
+            PartitionEntry entry = queue.PartitionManager.Partitions.FirstOrDefault(p => p.Label == "tenant-a");
+            Assert.NotNull(entry);
+            Assert.Equal(1, entry.Queue.Options.ClientLimit);
+        });
+    }
+
+    [Fact]
+    public async Task LowerDeclaration_DoesNotShrinkLivePartition_ButAppliesOnRecreate()
+    {
+        await TestHorseRider.RunWith(async (server, port) =>
+        {
+            await CreatePartitionedQueue(server, "pf-shrink-q", 1);
+
+            HorseClient c1 = new HorseClient();
+            await c1.ConnectAsync("horse://localhost:" + port);
+            HorseResult r1 = await c1.Queue.SubscribePartitioned("pf-shrink-q", "premium", true, 0, 2, CancellationToken.None);
+            Assert.Equal(HorseResultCode.Ok, r1.Code);
+
+            HorseClient c2 = new HorseClient();
+            await c2.ConnectAsync("horse://localhost:" + port);
+            HorseResult r2 = await c2.Queue.SubscribePartitioned("pf-shrink-q", "premium", true, 0, 2, CancellationToken.None);
+            Assert.Equal(HorseResultCode.Ok, r2.Code);
+
+            HorseQueue queue = server.Rider.Queue.Find("pf-shrink-q");
+            PartitionEntry entry = queue.PartitionManager.Partitions.FirstOrDefault(p => p.Label == "premium");
+            Assert.NotNull(entry);
+            Assert.Equal(2, entry.Queue.Options.ClientLimit);
+
+            // A lower declaration must not shrink the live partition (2 subscribers connected)
+            HorseClient c3 = new HorseClient();
+            await c3.ConnectAsync("horse://localhost:" + port);
+            HorseResult r3 = await c3.Queue.SubscribePartitioned("pf-shrink-q", "premium", true, 0, 1, CancellationToken.None);
+            Assert.Equal(HorseResultCode.LimitExceeded, r3.Code);
+            Assert.Equal(2, entry.Queue.Options.ClientLimit);
+            Assert.Equal(2, entry.Queue.ClientsCount());
+
+            // Disconnect subscribers so the label memory (last declared = 1) drives the re-create
+            c1.Disconnect();
+            c2.Disconnect();
+            c3.Disconnect();
+
+            await Task.Delay(3000);
+            Assert.Null(queue.PartitionManager.Partitions.FirstOrDefault(p => p.Label == "premium"));
+
+            HorseClient producer = new HorseClient();
+            await producer.ConnectAsync("horse://localhost:" + port);
+            await producer.Queue.Push("pf-shrink-q", Encoding.UTF8.GetBytes("msg"), false,
+                new[] { new KeyValuePair<string, string>(HorseHeaders.PARTITION_LABEL, "premium") }, CancellationToken.None);
+
+            await Task.Delay(500);
+
+            PartitionEntry recreated = queue.PartitionManager.Partitions.FirstOrDefault(p => p.Label == "premium");
+            Assert.NotNull(recreated);
+            Assert.Equal(1, recreated.Queue.Options.ClientLimit);
+        });
+    }
+}


### PR DESCRIPTION
A label partition's ClientLimit was frozen at creation time by whoever created it first. When a publisher re-created a partition after idle auto-destroy (RouteMessage passes no subscriber override), the partition fell back to the server default SubscribersPerPartition and every consumer beyond the first was rejected with LimitExceeded regardless of the capacity it declared.

- Remember the last consumer-declared subscribers-per-partition per label and prefer it over the server default on override-less (publisher-first) creation
- Upgrade a live partition's ClientLimit when a consumer declares a higher capacity; live partitions are never shrunk, lower declarations apply on the next re-creation
- Auto-assign paths (route intercept, starved-partition scan, new-worker placement) now check the partition's own ClientLimit (0 = unlimited) instead of the parent-level default, so pooled workers refill upgraded partitions

Tenant isolation is unchanged: flows that declare no override keep the server default capacity on every path.